### PR TITLE
Feature/couchbase sdk v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.0
 
+### 4.3.0
+    + Updating `couchbase` version to 2.4.0.
+
 ### 4.2.0
   * __Technical Debt__
     + Updating `couchbase` version to 2.3.4.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://secure.travis-ci.org/dsfields/couchbase-promises.svg)](https://travis-ci.org/dsfields/couchbase-promises)
 
+[![Dependency Status](https://img.shields.io/david/bentonam/couchbase-promises.svg?maxAge=2592000&style=flat-square)](https://david-dm.org/dsfields/couchbase-promises)
+
+[![devDependency Status](https://img.shields.io/david/dev/dsfields/couchbase-promises.svg?maxAge=2592000&style=flat-square)](https://david-dm.org/dsfields/couchbase-promises#info=devDependencies)
+
 __Contents__
 
   * [Overview](#overview)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "couchbase-promises",
   "longName": "Couchbase Promises",
   "description": "An A+ Promises wrapper for the Couchbase SDK with added support for batch mutation operations.",
-  "version": "4.2.0",
+  "version": "4.3.0",
 
   "dependencies": {
     "bluebird": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 
   "dependencies": {
     "bluebird": "^3.5.0",
-    "couchbase": "~2.3.4",
+    "couchbase": "~2.4.0",
     "elv": "^1.0.1"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
   "license": "MIT",
   "main": "./lib/couchbase",
   "peerDependencies": {
-    "couchbase": "2.3.x"
+    "couchbase": "2.4.x"
   },
   "private": false,
   "repository": {


### PR DESCRIPTION
Updated Couchbase SDK to version 2.4.0 which was released Sept. 2017 (https://developer.couchbase.com/server/other-products/release-notes-archives/nodejs-sdk#story-h2-2).  The SDK bump adds support for Couchbase Server 5.0 and allows for supporting role based security access to buckets, as you can no longer set a bucket password, it must be a user.  

When connecting to 5.x server and bucket with a password:

```
const couchbase = require('couchbase')
const cluster = new couchbase.Cluster('couchbase://localhost');
cluster.authenticate({
  username: 'someuser',
  password: 'somepassword'
});
const bucket = cluster.openBucket('default');
```

However when using the 2.4.0 sdk to connect to 4.x server and bucket with a password both of these approaches will still work
```
const couchbase = require('couchbase')
const cluster = new couchbase.Cluster('couchbase://localhost');
cluster.authenticate({
  password: 'somepassword'
});
const bucket = cluster.openBucket('default');
```

or 

```
const couchbase = require('couchbase')
const cluster = new couchbase.Cluster('couchbase://localhost');
const bucket = cluster.openBucket('default', 'somepassword');
```

For a bucket with no password:

```
const couchbase = require('couchbase')
const cluster = new couchbase.Cluster('couchbase://localhost');
const bucket = cluster.openBucket('default');
```